### PR TITLE
Added wildcard on objects and property name mapping

### DIFF
--- a/Sources/SwiftPath/Errors.swift
+++ b/Sources/SwiftPath/Errors.swift
@@ -22,4 +22,23 @@ public enum JsonPathEvaluateError: Error {
 	case indexOutOfBounds
     case unexpectedInternalNode
     case invalidJSONString
+    
+    public var localizedDescription: String {
+        switch self {
+        case .emptyPath: return "empty path"
+        case .invalidPathStart: return "invalid path start"
+        case .expectingSomethingNotNil: return "expecting something other than nil"
+        case .expectingAnObject: return "was expecting an object"
+        case .expectingAnArray: return "was expecting an array"
+        case .expectingAnArrayWithSomeValues: return "was expecting a non-empty array"
+        case .expectingAnArrayWithTwoOrMoreValues: return "was expecting an array with at least two values"
+        case .expectingANumber: return "was expecting a number"
+        case .invalidNode: return "invalid node"
+        case .evaluateSubPathFailed: return "failed to evaluate sub-path"
+        case .indexOutOfBounds: return "array index out of bounds"
+        case .unexpectedInternalNode: return "unexpected internal node"
+        case .invalidJSONString: return "invalid input json string"
+            
+        }
+    }
 }

--- a/Sources/SwiftPath/Parser.swift
+++ b/Sources/SwiftPath/Parser.swift
@@ -18,11 +18,14 @@ extension Parser {
         return (result, remainder.contextString)
     }
     
-    func followed(by rparser:Parser) -> Parser<[T]> {
+    func followed(by rparser:Parser, required: Bool = true) -> Parser<[T]> {
         return Parser<[T]>(parse: { scanner in
             guard let (lvalue, lscanner) = self.parse(scanner) else { return nil }
-            guard let (rvalue, rscanner) = rparser.parse(lscanner) else { return nil }
-            return ([lvalue, rvalue], rscanner)
+            if let (rvalue, rscanner) = rparser.parse(lscanner) {
+                return ([lvalue, rvalue], rscanner)
+            }
+            guard !required else { return nil }
+            return ([lvalue], lscanner)
         })
     }
     func followed(by rparsers:[Parser]) -> Parser<[T]> {

--- a/Sources/SwiftPath/PathParser.swift
+++ b/Sources/SwiftPath/PathParser.swift
@@ -26,25 +26,59 @@ internal struct PathParser {
     private static let Current = literal(string: "@").map { _ in PathNode.current }
     private static let Node = Root.or(Current)
     
+    /// wildcard
+    ///  the special "all values" property of an object
+    ///   $.book.*
+    ///  TODO: the special "all items" of an array
+    ///   $.books[*]
+    private static let Wildcard = literal(string: "*")
+    
     /// a dot-property
     /// specifies a named property of an object
     ///  .propName
     private static let Dot = literal(string: ".")
-    private static let DotPropertyName = pattern(string: "[a-zA-Z_][a-zA-Z0-9_$]*")
-    private static let DotProperty = Dot.followed(by: DotPropertyName).map { PathNode.property(name: $0[1]) }
-    
+    private static let DotPropertyName = pattern(string: "(?:[a-zA-Z_][a-zA-Z0-9_$]*)|\\*")
+    private static let DotProperty = Dot.followed(by: DotPropertyName).map { list -> PathNode in
+        if list[1] == "*" { return PathNode.values }
+        return PathNode.property(name: list[1])
+    }
+        
     /// quoted properties
     /// used with a subscript to access a property
     /// multiple properties can be comma separated
-    ///   ["propName"]
-    ///   ["prop1", "propTwo"]
+    ///   ["propName"] or ['propName']
+    ///   ["prop1", "propTwo"] or ['prop1', "prop2"]
     private static let Quote = literal(string: "\"")
+    private static let SingleQuote = literal(string: "'")
     private static let Comma = pattern(string: "\\s*,\\s*")
     
-    private static let SubscriptPropertyName = pattern(string: "[^ \t\r\n\"]+")
-    private static let SubscriptProperty = Quote.followed(by: [SubscriptPropertyName, Quote]).map { $0[1] }
+    private static let SubscriptPropertyName = pattern(string: "[^ \t\r\n\"\']+")
+    private static let QuotedSubscriptProperty = Quote.followed(by: [SubscriptPropertyName, Quote]).map { $0[1] }
+    private static let SingleQuotedSubscriptProperty = SingleQuote.followed(by: [SubscriptPropertyName, SingleQuote]).map { $0[1] }
+    
+    // subscript property parser -> String
+    private static let SubscriptProperty1 = QuotedSubscriptProperty.or(SingleQuotedSubscriptProperty)
+    
+    // subscript property parser -> (String, String)
+    private static let SubscriptProperty2 = QuotedSubscriptProperty.or(SingleQuotedSubscriptProperty).map { name -> (String, String) in
+        return (name, name)
+    }
+    
+    private static let RenameArrow = pattern(string: "\\s*=>\\s*")
+    private static let RenamedProperty = RenameArrow.followed(by: SubscriptProperty1).map { str -> (String, String) in return (str[1], str[1]) }
+    
+    private static let SubscriptProperty = SubscriptProperty2.followed(by: RenamedProperty, required: false).map { list -> (String, String) in
+        guard list.count > 1 else { return list[0] }
+        return (list[0].0, list[1].0)
+    }
+    
     private static let SubscriptPropertyList = SubscriptProperty.repeated(delimiter: Comma).map { list -> PathNode in
-        return list.count == 1 ? PathNode.property(name: list[0]) : PathNode.properties(names: list)
+        guard list.count > 1 else { return PathNode.property(name: list[0].0) }
+        let (names, rename) = list.reduce(into: ([String](), [String]())) {
+            $0.0.append($1.0)
+            $0.1.append($1.1)
+        }
+        return PathNode.properties(names: names, rename: rename)
     }
     
     /// index value

--- a/Sources/SwiftPath/SwiftPath.swift
+++ b/Sources/SwiftPath/SwiftPath.swift
@@ -27,7 +27,7 @@ public struct SwiftPath {
     }
     
     /// evaluate the SwiftPath on the specified JSON value
-    public func evaluate(with json:JsonValue) throws -> JsonValue? {
+    public func evaluate(with json: JsonValue) throws -> JsonValue? {
         var registers = [json]
         for part in precompute {
             guard let value = try part.evaluate(with: json, registers: registers) else {
@@ -38,10 +38,14 @@ public struct SwiftPath {
         return try path.evaluate(with: json, registers: registers)
     }
     
-    public func evaluate(with string:String) throws -> JsonValue? {
+    public func evaluate(with string: String) throws -> JsonValue? {
         guard let data = string.data(using: String.Encoding.utf8 ) else {
             throw JsonPathEvaluateError.invalidJSONString;
         }
+        return try evaluate(with: data)
+    }
+    
+    public func evaluate(with data: Data) throws -> JsonValue? {
         let json = try JSONSerialization.jsonObject(with: data)
         return try evaluate(with: json)
     }
@@ -53,7 +57,7 @@ public struct SwiftPath {
 	/// paths that need to be pre-computed
 	private let precompute: [SwiftPathPart]
 	
-	internal init(path: SwiftPathPart, precompute:[SwiftPathPart]? = nil) {
+	internal init(path: SwiftPathPart, precompute: [SwiftPathPart]? = nil) {
 		self.path = path
 		self.precompute = precompute ?? []
 	}

--- a/SwiftPath.xcodeproj/project.pbxproj
+++ b/SwiftPath.xcodeproj/project.pbxproj
@@ -49,15 +49,15 @@
 		F553E5C61F73E0280068B376 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5951F73DFBC0068B376 /* Errors.swift */; };
 		F553E5C71F73E0280068B376 /* PathNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E59A1F73DFBC0068B376 /* PathNode.swift */; };
 		F553E5C91F73E02D0068B376 /* CompiledPathTessts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E59F1F73DFFA0068B376 /* CompiledPathTessts.swift */; };
-		F553E5CA1F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTestes.swift */; };
+		F553E5CA1F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTests.swift */; };
 		F553E5CB1F73E02D0068B376 /* PathNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A11F73DFFA0068B376 /* PathNodeTests.swift */; };
 		F553E5CC1F73E02D0068B376 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A21F73DFFA0068B376 /* TestHelpers.swift */; };
 		F553E5CD1F73E02D0068B376 /* CompiledPathTessts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E59F1F73DFFA0068B376 /* CompiledPathTessts.swift */; };
-		F553E5CE1F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTestes.swift */; };
+		F553E5CE1F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTests.swift */; };
 		F553E5CF1F73E02D0068B376 /* PathNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A11F73DFFA0068B376 /* PathNodeTests.swift */; };
 		F553E5D01F73E02D0068B376 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A21F73DFFA0068B376 /* TestHelpers.swift */; };
 		F553E5D11F73E02D0068B376 /* CompiledPathTessts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E59F1F73DFFA0068B376 /* CompiledPathTessts.swift */; };
-		F553E5D21F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTestes.swift */; };
+		F553E5D21F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A01F73DFFA0068B376 /* PathArrayFunctionTests.swift */; };
 		F553E5D31F73E02D0068B376 /* PathNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A11F73DFFA0068B376 /* PathNodeTests.swift */; };
 		F553E5D41F73E02D0068B376 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553E5A21F73DFFA0068B376 /* TestHelpers.swift */; };
 		F5B17A761F752A7400D4D813 /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B17A751F752A7400D4D813 /* ParserTests.swift */; };
@@ -113,7 +113,7 @@
 		F553E59A1F73DFBC0068B376 /* PathNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathNode.swift; sourceTree = "<group>"; };
 		F553E59C1F73DFBC0068B376 /* Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
 		F553E59F1F73DFFA0068B376 /* CompiledPathTessts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompiledPathTessts.swift; sourceTree = "<group>"; };
-		F553E5A01F73DFFA0068B376 /* PathArrayFunctionTestes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathArrayFunctionTestes.swift; sourceTree = "<group>"; };
+		F553E5A01F73DFFA0068B376 /* PathArrayFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathArrayFunctionTests.swift; sourceTree = "<group>"; };
 		F553E5A11F73DFFA0068B376 /* PathNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathNodeTests.swift; sourceTree = "<group>"; };
 		F553E5A21F73DFFA0068B376 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		F553E5D61F73E1F00068B376 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -268,7 +268,7 @@
 				F553E59F1F73DFFA0068B376 /* CompiledPathTessts.swift */,
 				F5B17A751F752A7400D4D813 /* ParserTests.swift */,
 				F502B32A1F76908E0057525C /* PathParserTests.swift */,
-				F553E5A01F73DFFA0068B376 /* PathArrayFunctionTestes.swift */,
+				F553E5A01F73DFFA0068B376 /* PathArrayFunctionTests.swift */,
 				F553E5A11F73DFFA0068B376 /* PathNodeTests.swift */,
 				F553E5A21F73DFFA0068B376 /* TestHelpers.swift */,
 			);
@@ -620,7 +620,7 @@
 				F553E5CC1F73E02D0068B376 /* TestHelpers.swift in Sources */,
 				F5B17A761F752A7400D4D813 /* ParserTests.swift in Sources */,
 				B0542C721F4B80ED00EB5AA1 /* SwiftPathTests_iOS.swift in Sources */,
-				F553E5CA1F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */,
+				F553E5CA1F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */,
 				F502B32B1F76908E0057525C /* PathParserTests.swift in Sources */,
 				F553E5C91F73E02D0068B376 /* CompiledPathTessts.swift in Sources */,
 			);
@@ -634,7 +634,7 @@
 				F553E5D01F73E02D0068B376 /* TestHelpers.swift in Sources */,
 				F5B17A771F752A7400D4D813 /* ParserTests.swift in Sources */,
 				B0542C811F4B810200EB5AA1 /* SwiftPathTests_tvOS.swift in Sources */,
-				F553E5CE1F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */,
+				F553E5CE1F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */,
 				F502B32C1F76908E0057525C /* PathParserTests.swift in Sources */,
 				F553E5CD1F73E02D0068B376 /* CompiledPathTessts.swift in Sources */,
 			);
@@ -648,7 +648,7 @@
 				F553E5D41F73E02D0068B376 /* TestHelpers.swift in Sources */,
 				F5B17A781F752A7400D4D813 /* ParserTests.swift in Sources */,
 				B0542C901F4B811100EB5AA1 /* SwiftPathTests_macOS.swift in Sources */,
-				F553E5D21F73E02D0068B376 /* PathArrayFunctionTestes.swift in Sources */,
+				F553E5D21F73E02D0068B376 /* PathArrayFunctionTests.swift in Sources */,
 				F502B32D1F76908E0057525C /* PathParserTests.swift in Sources */,
 				F553E5D11F73E02D0068B376 /* CompiledPathTessts.swift in Sources */,
 			);

--- a/Tests/SwiftPathTests/PathArrayFunctionTestes.swift
+++ b/Tests/SwiftPathTests/PathArrayFunctionTestes.swift
@@ -109,13 +109,6 @@ class PathArrayFunctionTestes: XCTestCase {
 		// expected precision
 		let precision = 1E-10
 		
-		// some oddball comparisons that came up:
-		//  comparing -487.054 with -487.054 - diff is 1.13686837721616e-13
-		//  comparing -20.671 with -20.671 - diff is 3.5527136788005e-15
-		//  comparing 365.22564369989 with 365.225643699891 - diff is 1.36424205265939e-12
-		//  comparing 302.63954467981 with 302.639544679806 - diff is 4.49063009000383e-12
-		//  comparing 59.232366903577 with 59.2323669035773 - diff is 3.05533376376843e-13
-		
 		for test in tests {
 			do {
 				if let result = try test.function.evaluate(array: test.numbers) as? Double {
@@ -127,7 +120,7 @@ class PathArrayFunctionTestes: XCTestCase {
 						equal = result.isNaN
 					}
 					else {
-						equal = abs(test.expectedResult - result) < precision
+                        equal = abs(test.expectedResult - result) < precision
 					}
 					XCTAssert(equal, "\(test.function) failed: expecting \(test.expectedResult) got \(result) for \(test.numbers)")
 				}
@@ -140,5 +133,4 @@ class PathArrayFunctionTestes: XCTestCase {
 			}
 		}
 	}
-    
 }

--- a/Tests/SwiftPathTests/PathArrayFunctionTests.swift
+++ b/Tests/SwiftPathTests/PathArrayFunctionTests.swift
@@ -1,5 +1,5 @@
 //
-//  PathArrayFunctionTestes.swift
+//  PathArrayFunctionTests.swift
 //  JsonPathTests
 //
 //  Created by Steven Grosmark on 8/20/17.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwiftPath
 
-class PathArrayFunctionTestes: XCTestCase {
+class PathArrayFunctionTests: XCTestCase {
 	
 	let positives = [ 980.87, 509.42, 11.98, 165.31, 791.29, 834.18, 68.69, 817.87, 994.97, 862.40 ]
 	let negatives = [ -194.65, -790.89, -696.61, -322.70, -803.83, -57.13, -162.76, -646.61, -260.87, -934.49 ]

--- a/Tests/SwiftPathTests/PathNodeTests.swift
+++ b/Tests/SwiftPathTests/PathNodeTests.swift
@@ -32,6 +32,14 @@ class PathNodeTests: XCTestCase {
 			try Expecting.string("the summary value", result: result)
 		}
     }
+    
+    func testProperyValues() {
+        let node = PathNode.values
+        runTest("property values") {
+            let result = try node.process(with: jsonObject, registers: [])
+            try Expecting.array(["the name value", "the summary value", "the three value"], ordered: false, result: result)
+        }
+    }
 	
 	func testCollatedProperty() {
 		var array: JsonArray = []
@@ -47,10 +55,10 @@ class PathNodeTests: XCTestCase {
 	}
 	
 	func testPropertyList() {
-		let node = PathNode.properties(names: ["summary", "three"])
+        let node = PathNode.properties(names: ["summary", "three"], rename: ["summary", "third"])
 		runTest("property list") {
 			let result = try node.process(with: jsonObject, registers: [])
-			try Expecting.object(["summary":"the summary value", "three":"the three value"], result: result)
+			try Expecting.object(["summary":"the summary value", "third":"the three value"], result: result)
 		}
 	}
 	

--- a/Tests/SwiftPathTests/PathParserTests.swift
+++ b/Tests/SwiftPathTests/PathParserTests.swift
@@ -71,4 +71,109 @@ class PathParserTests: XCTestCase {
         XCTAssertEqual(index, 0)
     }
     
+    func testSingleQuotedPropertyOnRoot() {
+        let result = PathParser.parse(path: "$['property']")
+        XCTAssertNotNil(result)
+        guard case let .path(base, nodes) = result! else {
+            XCTFail("PathParser.parse returned unexpected node type")
+            return
+        }
+        guard case .root = base else {
+            XCTFail("expected a root node")
+            return
+        }
+        XCTAssert(nodes.count == 1)
+        guard case let .property(name) = nodes[0] else {
+            XCTFail("expecting a property node")
+            return
+        }
+        XCTAssertEqual(name, "property")
+    }
+    
+    func testDoubleQuotedPropertyOnRoot() {
+        let result = PathParser.parse(path: "$[\"property\"]")
+        XCTAssertNotNil(result)
+        guard case let .path(base, nodes) = result! else {
+            XCTFail("PathParser.parse returned unexpected node type")
+            return
+        }
+        guard case .root = base else {
+            XCTFail("expected a root node")
+            return
+        }
+        XCTAssert(nodes.count == 1)
+        guard case let .property(name) = nodes[0] else {
+            XCTFail("expecting a property node")
+            return
+        }
+        XCTAssertEqual(name, "property")
+    }
+    
+    func testQuotedPropertiesOnRoot() {
+        let result = PathParser.parse(path: "$[\"property\", 'another'=>'new-name', 'three']")
+        XCTAssertNotNil(result)
+        guard case let .path(base, nodes) = result! else {
+            XCTFail("PathParser.parse returned unexpected node type")
+            return
+        }
+        guard case .root = base else {
+            XCTFail("expected a root node")
+            return
+        }
+        XCTAssert(nodes.count == 1)
+        guard case let .properties(names, rename) = nodes[0] else {
+            XCTFail("expecting a properties node")
+            return
+        }
+        XCTAssertEqual(names, ["property", "another", "three"])
+        XCTAssertEqual(rename, ["property", "new-name", "three"])
+    }
+    
+    func testWildcard() {
+        let result = PathParser.parse(path: "$.*")
+        XCTAssertNotNil(result)
+        guard case let .path(base, nodes) = result! else {
+            XCTFail("PathParser.parse returned unexpected node type")
+            return
+        }
+        guard case .root = base else {
+            XCTFail("expected a root node")
+            return
+        }
+        XCTAssert(nodes.count == 1)
+        guard case .values = nodes[0] else {
+            XCTFail("expecting a values node")
+            return
+        }
+    }
+    
+    func testWildcard2() {
+        let result = PathParser.parse(path: "$.coins.*[\"name\", \"ticker\"=>'symbol', 'exchange_rate_btc' => \"btc\"]")
+        XCTAssertNotNil(result)
+        guard case let .path(base, nodes) = result! else {
+            XCTFail("PathParser.parse returned unexpected node type")
+            return
+        }
+        guard case .root = base else {
+            XCTFail("expected a root node")
+            return
+        }
+        XCTAssert(nodes.count == 3)
+        guard case let .property(name) = nodes[0] else {
+            XCTFail("expecting a property node")
+            return
+        }
+        XCTAssertEqual(name, "coins")
+        guard case .values = nodes[1] else {
+            XCTFail("expecting a values node")
+            return
+        }
+        guard case let .properties(names, rename) = nodes[2] else {
+            XCTFail("expecting a properties node")
+            return
+        }
+        XCTAssertEqual(names, ["name", "ticker", "exchange_rate_btc"])
+        XCTAssertEqual(rename, ["name", "symbol", "btc"])
+    }
+    
 }

--- a/Tests/SwiftPathTests/TestHelpers.swift
+++ b/Tests/SwiftPathTests/TestHelpers.swift
@@ -59,23 +59,38 @@ class Expecting {
 		}
 	}
 	
-	static func array(_ array:[String], result inResult:JsonValue?) throws {
+    static func array(_ array:[String], ordered: Bool = true, result inResult:JsonValue?) throws {
 		guard let result = inResult as? JsonArray else {
 			throw "property result not an array \(String(describing: inResult))"
 		}
 		guard result.count == array.count else {
 			throw "property result has wrong count: expecting \(array.count) found \(result.count)"
 		}
-		for (idx, resultItem) in result.enumerated() {
-			if let value = resultItem as? String {
-				if array[idx] != value {
-					throw "string mismatch - expecting \"\(array[idx])\" got \"\(value)\""
-				}
-			}
-			else {
-				throw "property result item isn't a string: \(resultItem)"
-			}
-		}
+        if ordered {
+            for (idx, resultItem) in result.enumerated() {
+                if let value = resultItem as? String {
+                    if array[idx] != value {
+                        throw "string mismatch - expecting \"\(array[idx])\" got \"\(value)\""
+                    }
+                }
+                else {
+                    throw "property result item isn't a string: \(resultItem)"
+                }
+            }
+        }
+        else {
+            let expectedSet = array.countedSet()
+            let resultSet = result.countedSet()
+            if expectedSet != resultSet {
+                throw "unordered arrays don't match"
+            }
+        }
 	}
+}
+
+extension Array where Element: Any {
+    func countedSet() -> NSCountedSet {
+        return self.reduce(into: NSCountedSet()) { $0.add($1) }
+    }
 }
 


### PR DESCRIPTION
Added ability to add a wildcard to objects:
```
$.books.*
```
Doing so converts the current object to an array of it's values - e.g. from this:
```json
{
  "books" : {
    "one" : { "title": "one" },
    "two" : { "title": "two" },
    "three" : { "title": "three" }
  }
}
```
to this:
```json
[ { "title": "one" }, { "title": "two" }, { "title": "three" } ]
```

Also added ability to map property names when collecting a subset of properties, like this:
Json:
```json
[
  {"name": "one", "value": 1, "extra": true },
  {"name": "one", "value": 2, "extra": true },
  {"name": "one", "value": 3, "extra": true }
]
```

Json path:
```
$['name', 'value'=>'id']
```

Evaluates to:
```json
[
  {"name": "one", "id": 1 },
  {"name": "one", "id": 2 },
  {"name": "one", "id": 3 }
]
```