### PR TITLE
Run migration tool for conversion to Swift 4.2

### DIFF
--- a/Sources/SwiftPath/ArrayFunctions.swift
+++ b/Sources/SwiftPath/ArrayFunctions.swift
@@ -35,30 +35,30 @@ internal extension ArrayFunction {
 		
 		case .minimum:
 			guard array.count > 0 else { throw JsonPathEvaluateError.expectingAnArrayWithSomeValues }
-			let doubles: [Double] = array.flatMap({ $0 as? Double })
+			let doubles: [Double] = array.compactMap { $0 as? Double }
 			guard doubles.count == array.count else { throw JsonPathEvaluateError.expectingANumber }
 			return doubles.reduce(doubles[0], { $0 < $1 ? $0 : $1 })
 		
 		case .maximum:
 			guard array.count > 0 else { throw JsonPathEvaluateError.expectingAnArrayWithSomeValues }
-			let doubles: [Double] = array.flatMap({ $0 as? Double })
+			let doubles: [Double] = array.compactMap { $0 as? Double }
 			guard doubles.count == array.count else { throw JsonPathEvaluateError.expectingANumber }
 			return doubles.reduce(doubles[0], { $0 > $1 ? $0 : $1 })
 		
 		case .average:
 			guard array.count > 0 else { throw JsonPathEvaluateError.expectingAnArrayWithSomeValues }
-			let doubles: [Double] = array.flatMap({ $0 as? Double })
+			let doubles: [Double] = array.compactMap { $0 as? Double }
 			guard doubles.count == array.count else { throw JsonPathEvaluateError.expectingANumber }
 			return doubles.reduce(0, {$0 + $1}) / Double(doubles.count)
 		
 		case .sum:
-			let doubles: [Double] = array.flatMap({ $0 as? Double })
+			let doubles: [Double] = array.compactMap { $0 as? Double }
 			guard doubles.count == array.count else { throw JsonPathEvaluateError.expectingANumber }
 			return doubles.reduce(0, {$0 + $1})
 		
 		case .standardDeviation:
 			guard array.count >= 2 else { throw JsonPathEvaluateError.expectingAnArrayWithTwoOrMoreValues }
-			let doubles: [Double] = array.flatMap({ $0 as? Double })
+			let doubles: [Double] = array.compactMap { $0 as? Double }
 			guard doubles.count == array.count else { throw JsonPathEvaluateError.expectingANumber }
 			let length = Double(doubles.count)
 			let avg = doubles.reduce(0, {$0 + $1}) / length

--- a/Sources/SwiftPath/PathParser.swift
+++ b/Sources/SwiftPath/PathParser.swift
@@ -88,7 +88,7 @@ internal struct PathParser {
     ///   [0, 2, 4]
     private static let IndexValue = pattern(string: "-?[0-9]+").map { Int($0) }
     private static let IndexValueList = IndexValue.repeated(delimiter: Comma).map { list -> PathNode in
-        let flat = list.flatMap { $0 }
+        let flat = list.compactMap { $0 }
         return flat.count == 1 ? PathNode.arrayItem(index: flat[0]) : PathNode.arrayItems(indices: flat)
     }
     

--- a/SwiftPath.xcodeproj/project.pbxproj
+++ b/SwiftPath.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 				TargetAttributes = {
 					B0266CA31F4B76A300FCD856 = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 1010;
 					};
 					B0266CB11F4B76BF00FCD856 = {
 						CreatedOnToolsVersion = 9.0;
@@ -467,6 +468,7 @@
 					};
 					B0542C6E1F4B80ED00EB5AA1 = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 1010;
 					};
 					B0542C7D1F4B810200EB5AA1 = {
 						CreatedOnToolsVersion = 9.0;
@@ -742,7 +744,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -808,7 +810,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1294,7 +1296,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1351,7 +1353,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
The conversions include using compactMap over flatMap which is
deprecated in Xcode 10.0 SDK.