### PR TITLE
Make Package consumable my swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftPath",
+    products: [
+      .library(name: "SwiftPath", targets: ["SwiftPath"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "SwiftPath",
+            dependencies: []),
+    ]
+)


### PR DESCRIPTION
I don't know anything about Swift, but that seems to allow me to declare a dependency on SwiftPath.

If you decide to merge, be advised that the package manager will need a new release to find a tag with the matching Package.swift file.

```
$ cat Package.swift
// swift-tools-version:5.1
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
  name: "Swift_SwiftPath",
  dependencies: [
    .package(url: "https://github.com/cburgmer/SwiftPath.git", from: "0.2.1"),
  ],
  targets: [
    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
    .target(
      name: "Swift_SwiftPath",
      dependencies: ["SwiftPath"]),
  ]
)
```